### PR TITLE
Add paper-plugin-loader and paper-skip-libraries support for bu…

### DIFF
--- a/src/main/kotlin/net/minecrell/pluginyml/bukkit/BukkitPluginDescription.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/bukkit/BukkitPluginDescription.kt
@@ -38,6 +38,8 @@ class BukkitPluginDescription(project: Project) : PluginDescription() {
     @Input @Optional var provides: List<String>? = null
     @Input @Optional var libraries: List<String>? = null
     @Input @Optional @JsonProperty("folia-supported") var foliaSupported: Boolean? = null
+    @Input @Optional @JsonProperty("paper-plugin-loader") var paperPluginLoader: String? = null
+    @Input @Optional @JsonProperty("paper-skip-libraries") var paperSkipLibraries: Boolean? = null
 
     @Nested val commands: NamedDomainObjectContainer<Command> = project.container(Command::class.java)
     @Nested val permissions: NamedDomainObjectContainer<Permission> = project.container(Permission::class.java)


### PR DESCRIPTION
This pull request adds [paper-plugin-loader](https://docs.papermc.io/paper/dev/plugin-yml/#paper-plugin-loader) and [paper-skip-libraries](https://docs.papermc.io/paper/dev/plugin-yml/#paper-skip-libraries). They were added in racent Paper versions to allow plugins to have their own library loading logic without having to use [paper plugins](https://docs.papermc.io/paper/dev/getting-started/paper-plugins/).

Closes #38 .